### PR TITLE
fix: add package-lock.json to fix CI workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/Jhon-Crow/focus-desktop-simulator/issues/3
-Your prepared branch: issue-3-8b4ac6e35090
-Your prepared working directory: /tmp/gh-issue-solver-1767016150553
-Your forked repository: konard/Jhon-Crow-focus-desktop-simulator
-Original repository (upstream): Jhon-Crow/focus-desktop-simulator
-
-Proceed.


### PR DESCRIPTION
## Summary

This PR fixes the CI workflow failure by adding the missing `package-lock.json` file.

**Root Cause Analysis:**
- The GitHub Actions workflow at `.github/workflows/build.yml` uses `actions/setup-node@v4` with `cache: 'npm'` (line 24)
- This caching feature requires a lock file (`package-lock.json`, `npm-shrinkwrap.json`, or `yarn.lock`) to be present
- The repository was missing this file, causing the error: `Dependencies lock file is not found`

**Solution:**
- Generated `package-lock.json` by running `npm install`
- The lock file pins all dependency versions for reproducible builds

## Test Plan

- [ ] Verify CI workflow runs successfully after merging
- [ ] Ensure all dependencies are properly resolved

Fixes #3

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)