### PR TITLE
feat: добавить диктофон

### DIFF
--- a/src/preload.js
+++ b/src/preload.js
@@ -6,6 +6,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // Separate handlers for large data (PDF, cover images) to avoid lag
   saveObjectData: (objectId, dataType, dataUrl) => ipcRenderer.invoke('save-object-data', objectId, dataType, dataUrl),
   loadObjectData: (objectId, dataType) => ipcRenderer.invoke('load-object-data', objectId, dataType),
+  // FFmpeg status - check if FFmpeg is available
+  getFfmpegStatus: () => ipcRenderer.invoke('get-ffmpeg-status'),
+  // Listen for FFmpeg status updates from main process
+  onFfmpegStatus: (callback) => ipcRenderer.on('ffmpeg-status', (event, available) => callback(available)),
   // Audio transcoding using FFmpeg (for files that browser can't decode)
   transcodeAudio: (audioDataBase64, fileName) => ipcRenderer.invoke('transcode-audio', audioDataBase64, fileName),
   // Cassette player - music folder selection and audio file reading


### PR DESCRIPTION
## 🎙️ Добавлен диктофон

Эта реализация добавляет минималистичный пластмассовый микрофон-диктофон на рабочий стол.

### 📋 Ссылка на issue
Fixes #43

### ✅ Реализованные функции

**3D модель:**
- Весь чёрный, минималистичный дизайн
- Плоская прямоугольная стойка
- Длинная тонкая ножка, **наклонённая вперёд (~15°) и слегка изогнутая**
- Маленький овальный "паралон" на конце

**Кнопка записи:**
- Круглая кнопка на стойке (как кнопка включения ноутбука)
- Нажатие включает/выключает запись

**LED индикатор:**
- Рядом с кнопкой маленький светодиод
- Когда запись не идёт - его почти не видно
- Когда запись идёт - светится красным с пульсацией, освещая пространство вокруг

**Запись звука:**
- Записывает звуки с микрофона пользователя
- **Записывает виртуальные звуки комнаты** (музыку с кассетного плеера и другие источники)
- Использует **MediaRecorder** — работает в фоновом потоке, не блокирует рендеринг
- **Форматы:** 
  - WAV — требует FFmpeg
  - MP3 — требует FFmpeg
  - WebM — работает всегда (нативный формат MediaRecorder)
- После выключения запись автоматически сохраняется как "Запись N"

**Настройки (edit mode):**
- Можно указать папку для сохранения файлов
- Можно выбрать формат: WAV, MP3 или WebM
- **WAV/MP3 кнопки автоматически отключаются если FFmpeg не установлен**
- Показывается статус FFmpeg (установлен / не установлен)
- Показывается статус записи
- Показывается номер следующей записи

**FFmpeg определение и автоустановка:**
- При запуске приложения автоматически проверяется наличие FFmpeg
- Если FFmpeg не найден, выполняется попытка автоустановки:
  - **Windows:** через winget
  - **macOS:** через brew
  - **Linux:** через apt-get
- Статус FFmpeg передаётся в renderer для отображения доступности форматов

### 🔧 Технические детали

**Общая аудио-система:**
- Создан единый `sharedAudioSystem` для всех источников звука
- Кассетный плеер и диктофон используют один `AudioContext`
- Весь звук проходит через `masterGain` → `recordingGain`, который диктофон захватывает

**Конвертация аудио:**
- WAV: конвертация через FFmpeg
- MP3: конвертация через FFmpeg
- WebM: нативный формат браузера, работает всегда

**Исправленные проблемы:**
- ✅ Серый экран во время записи (заменён ScriptProcessorNode на MediaRecorder)
- ✅ Файлы не сохранялись (улучшена обработка ошибок)
- ✅ Звуки виртуальной комнаты не записывались (добавлена общая аудио-система)
- ✅ WAV/MP3 недоступны без FFmpeg (добавлено определение и отключение кнопок)

### 🧪 Как тестировать

1. Запустить приложение: `npm install && npm start`
2. В палитре инструментов выбрать категорию "Audio" 🎵
3. Выбрать "Dictaphone" 🎙️ и добавить на стол
4. Нажать на диктофон - откроется диалог выбора папки для записей
5. После выбора папки нажать снова - начнётся запись (LED загорится красным)
6. **Для записи виртуальных звуков:** запустить музыку на кассетном плеере во время записи
7. Нажать ещё раз - запись остановится и сохранится в выбранную папку
8. Проверить консоль DevTools для диагностических сообщений

### 📁 Изменённые файлы

- `src/main.js` - IPC обработчики для сохранения записей, определение FFmpeg, автоустановка
- `src/preload.js` - API для записи, получение статуса FFmpeg
- `src/renderer.js` - 3D модель, логика записи, общая аудио-система, отключение форматов без FFmpeg

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)