### PR TITLE
fix: sync white noise (tape hiss) volume with main player volume

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/Jhon-Crow/focus-desktop-simulator/issues/56
-Your prepared branch: issue-56-7e83628dec0e
-Your prepared working directory: /tmp/gh-issue-solver-1767249862819
-Your forked repository: konard/Jhon-Crow-focus-desktop-simulator
-Original repository (upstream): Jhon-Crow/focus-desktop-simulator
-
-Proceed.


### PR DESCRIPTION
## Summary
- When changing the main volume slider on cassette/walkman players, the white noise (tape hiss) now changes proportionally
- Previously, the noise gain was only scaled by the tape hiss level setting, but not by the main volume

## Changes
- Scale noise gain by volume during initial playback setup (`playCassetteTrack`)
- Scale noise gain by volume when resuming paused playback (`toggleCassettePlayback`)
- Update noise gain when volume slider changes in the UI
- Scale noise gain by volume when tape hiss slider changes

## Technical Details

The issue was in the audio chain architecture. The cassette player creates two parallel audio paths that merge before output:

```
Music: source -> effects -> mainGain -> merger -> output
Noise:          noiseSource -> noiseGain -> merger
```

Previously, when the volume slider changed, only `mainGain` was updated, leaving `noiseGain` at a fixed level. Now `noiseGain` is calculated as `0.015 * hissLevel * volume`, ensuring white noise respects the main volume setting.

## Test plan
- [ ] Add a cassette or walkman player to the desk
- [ ] Load audio files and start playback
- [ ] Verify tape hiss is audible at high volume
- [ ] Lower the volume slider to 0%
- [ ] Verify tape hiss becomes silent along with the music
- [ ] Raise volume back up, verify hiss returns proportionally
- [ ] Test pause/resume - hiss should respect current volume setting

Fixes Jhon-Crow/focus-desktop-simulator#56

🤖 Generated with [Claude Code](https://claude.com/claude-code)