### PR TITLE
fix: restart playback when folder changes and fix big player stacking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/Jhon-Crow/focus-desktop-simulator/issues/66
-Your prepared branch: issue-66-796420bd5510
-Your prepared working directory: /tmp/gh-issue-solver-1767307214340
-Your forked repository: konard/Jhon-Crow-focus-desktop-simulator
-Original repository (upstream): Jhon-Crow/focus-desktop-simulator
-
-Proceed.


### PR DESCRIPTION
## Summary

This PR fixes two issues with the cassette player as described in #66:

1. **Music folder change during playback**: When changing the music folder while a track is playing, playback now automatically stops and restarts with the first track from the new folder
2. **Big player collision/stacking issues**: Fixed collision issues where objects (like laptops) would fall through or collide incorrectly when placed on top of the big cassette player

## Changes Made

### 1. Folder Change Playback Fix (`src/renderer.js:11587-11622`)

- Added logic to detect if the player is currently playing before folder change
- Stops current playback when changing folder
- Automatically starts playing the first track from the new folder if player was previously playing
- Ensures smooth transition between music folders during active playback

**Modified function**: `setupCassetteCustomizationHandlers()` - folder selection button click handler

### 2. Big Player Stacking Physics Fix (`src/renderer.js:1812-1813`)

Added missing physics entries for both cassette players to `OBJECT_PHYSICS` constant:

- **Mini cassette player**: `height: 0.08` (matches actual model dimensions)
- **Big cassette player**: `height: 0.12` (matches actual model dimensions)

**Root cause**: The physics system was using default height of `0.3` for both players, which didn't match their actual dimensions (`0.08` and `0.12` respectively). This caused the stacking detection logic to calculate incorrect vertical positions, making it impossible to properly place objects on top of the big player.

**Impact**: Objects can now be correctly placed on top of cassette players without falling through or experiencing collision glitches.

## Technical Details

The stacking system uses `getObjectPhysics()` to determine each object's height for calculating where the top surface is located:
```javascript
const baseTop = baseObject.position.y + basePhysics.height;
```

Without proper physics entries, the cassette players were using the default fallback height, causing a mismatch between the visual model and the collision detection system.

## Testing

- Verified folder change during playback restarts with first track
- Verified collision physics now properly supports stacking objects on big player
- CI build check: In progress

## Fixes

Fixes #66

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)