### PR TITLE
fix: only save markdown file when Save button is clicked

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/Jhon-Crow/focus-desktop-simulator/issues/100
-Your prepared branch: issue-100-7ef79f7e8911
-Your prepared working directory: /tmp/gh-issue-solver-1767704438954
-Your forked repository: konard/Jhon-Crow-focus-desktop-simulator
-Original repository (upstream): Jhon-Crow/focus-desktop-simulator
-
-Proceed.


### PR DESCRIPTION
## 📝 Summary

This PR fixes the markdown editor to only save `.md` files to disk when the user explicitly clicks the **Save** button, instead of saving on every editor close action.

## 🐛 Problem

Previously, the markdown file was automatically saved to the file system every time the editor was closed, regardless of how it was closed:
- Clicking the close button (×)
- Pressing the Escape key
- Middle-clicking to exit laptop mode

This behavior gave users no control over when files were actually written to disk.

## ✅ Solution

Modified the `saveAndClose()` function in `src/renderer.js:18590-18623` to remove the automatic file-saving logic. Now:

- **Save button clicked**: Saves content to both app state AND disk file
- **Editor closed** (via ×, Escape, or middle-click): Only saves to app state (userData), NOT to disk

This gives users explicit control over when their markdown files are saved to the file system, while still preserving the content within the app for session persistence.

## 🔧 Changes Made

- Removed file-saving code from `saveAndClose()` function (removed ~30 lines)
- Changed function from `async` to regular since it no longer needs to await file operations
- File-saving logic remains intact in the Save button click handler

## 📋 Testing

The changes can be tested by:
1. Opening the markdown editor (Obsidian icon on laptop)
2. Typing some content
3. Closing the editor without clicking Save
4. Checking that no new timestamped `.md` file was created
5. Reopening the editor and clicking Save
6. Verifying that the file is now saved to disk with timestamp

## 🔗 Related

Fixes #100

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)