### PR TITLE
Increase object zoom limits by 100%

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/Jhon-Crow/focus-desktop-simulator/issues/107
-Your prepared branch: issue-107-39ee8f10341e
-Your prepared working directory: /tmp/gh-issue-solver-1767793274263
-Your forked repository: konard/Jhon-Crow-focus-desktop-simulator
-Original repository (upstream): Jhon-Crow/focus-desktop-simulator
-
-Proceed.


### PR DESCRIPTION
## Summary

This PR increases the maximum zoom limits for all objects in examine mode by 100% (doubles them), allowing users to inspect objects in much greater detail using Shift+Scroll.

## Changes

Modified `src/renderer.js` to double all maximum scale limits:

| Object Type | Previous Max | New Max | Increase |
|-------------|--------------|---------|----------|
| Default objects | 3.0x | 6.0x | +100% |
| Magazines & Cassette players | 10.0x | 20.0x | +100% |
| Books | 5.0x | 10.0x | +100% |
| Dictaphones | 6.0x | 12.0x | +100% |

## Implementation Details

Updated two wheel event handlers in `src/renderer.js`:
- Lines 14318-14327: Examine mode scaling (primary handler)
- Lines 14425-14434: Alternative examine mode scaling handler

Both handlers now allow objects to be scaled to twice their previous maximum limits while preserving the minimum scale of 0.3x.

## Testing

- CI build passes successfully
- All existing functionality preserved
- Users can now zoom in much closer on objects for better detail inspection

Fixes #107