### PR TITLE
Add MMB hold to exit reading mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/Jhon-Crow/focus-desktop-simulator/issues/117
-Your prepared branch: issue-117-a25aee101a5c
-Your prepared working directory: /tmp/gh-issue-solver-1767794343034
-Your forked repository: konard/Jhon-Crow-focus-desktop-simulator
-Original repository (upstream): Jhon-Crow/focus-desktop-simulator
-
-Proceed.


### PR DESCRIPTION
## Summary

This PR implements the ability to exit reading mode by holding the middle mouse button (MMB) for 300ms, as requested in issue #117.

## Changes

### Modified Files
- `src/renderer.js`: Updated mouse event handlers to support MMB hold detection in reading mode

### Implementation Details

#### 1. **MMB Hold Detection in Reading Mode** (src/renderer.js:12594-12603)
When MMB is pressed while in reading mode:
- Records the press timestamp
- Sets up a 300ms timeout
- If held for 300ms, automatically calls `exitBookReadingMode()`
- Follows the same pattern used for player mode and other interactive modes

#### 2. **MMB Quick Release Handling** (src/renderer.js:13727-13734)
When MMB is released in reading mode:
- Cancels the hold timeout if released before 300ms
- Quick clicks do nothing (no action in reading mode)
- Prevents accidental exits from brief MMB presses

## Behavior

### How to Exit Reading Mode (After This PR)
1. **Hold MMB for 300ms** (NEW) - Exits reading mode with smooth camera animation
2. **Click LMB** (existing) - Still works as before

### Consistency with Existing Code
This implementation follows the exact same pattern already used in the codebase for:
- Player mode exit (MMB hold for 300ms)
- Pen drawing mode entry (MMB hold for 300ms)
- Inspection+drawing mode entry (MMB hold for 300ms)
- Floor object deletion (MMB hold for 300ms)

## Testing

The implementation:
- ✅ Uses existing `bookReadingState.holdTimeout` field (already defined in state object)
- ✅ Uses existing `exitBookReadingMode()` function (no changes needed)
- ✅ Follows established timeout pattern used throughout the codebase
- ✅ Preserves existing LMB exit functionality
- ✅ Doesn't interfere with zoom/pan controls in reading mode

## Fixes

Fixes #117

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)